### PR TITLE
chore: dedupe preloads array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export default {
       return response;
     }
 
-    const preloads: PreloadResourceHint[] = [];
+    let preloads: PreloadResourceHint[] = [];
 
     class ElementHandler {
       element(element: Element) {
@@ -59,6 +59,7 @@ export default {
     const body = await transformed.text();
     const headers = new Headers(response.headers);
 
+    preloads = [...new Map(preloads.map(v => [v.url, v])).values()]
     preloads.forEach((element) => {
       headers.append(
         "link",


### PR DESCRIPTION
On sites where the same image appeared multiple times (i.e avatars on a comment section), the same resource would be added to the `link` header multiple times.

This addresses that by de-duplicating the `preloads` array before we iterate over it. Ref: https://stackoverflow.com/a/70406623